### PR TITLE
added phtml to the available extensions for parsing html

### DIFF
--- a/tasks/extract.js
+++ b/tasks/extract.js
@@ -108,7 +108,7 @@ module.exports = function(grunt) {
         });
       };
       file.src.forEach(function(input) {
-        if (input.match(/\.(htm(|l)|php)$/)) {
+        if (input.match(/\.(htm(|l)|php|phtml)$/)) {
           extractHtml(input);
         }
         if (input.match(/\.js$/)) {


### PR DESCRIPTION
As some php frameworks do use phtml for their html partial views, I added the extension to the list.

If you want i can take a look at refactoring this into an option in the grunt task. where you can supply additional extensions to extend the array of available files.
