### PR TITLE
Add concat option for using with usemin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-angular-gettext",
   "description": "Tasks for extracting/compiling angular-gettext strings.",
-  "version": "0.1.3",
+  "version": "0.1.3.1",
   "homepage": "http://angular-gettext.rocketeer.be/",
   "author": {
     "name": "Ruben Vermeersch",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-angular-gettext",
   "description": "Tasks for extracting/compiling angular-gettext strings.",
-  "version": "0.1.3.1",
+  "version": "0.1.4",
   "homepage": "http://angular-gettext.rocketeer.be/",
   "author": {
     "name": "Ruben Vermeersch",

--- a/tasks/compile.js
+++ b/tasks/compile.js
@@ -1,7 +1,7 @@
-var langTemplate, po, template;
+var langTemplate, po, path, template;
 
 po = require('node-po');
-var path = require('path');
+path = require('path');
 
 template = function(module, body) {
   return "angular.module(\"" + module + "\").run(['gettextCatalog', function (gettextCatalog) {\n" + body + "\n}]);";


### PR DESCRIPTION
This adds a concat option to the compile task. The code is copied from grunt-angular-templates. The option adds the output of the compile task to the concat target specified by the option. This then enables usemin to include the compiled output in its build tasks.
