### PR TITLE
Added debug messages extract task to make is easier to debug problems

### DIFF
--- a/tasks/extract.js
+++ b/tasks/extract.js
@@ -52,6 +52,7 @@ module.exports = function (grunt) {
             }
 
             function extractHtml(filename) {
+                grunt.log.debug("Extracting " + filename);
                 var src = grunt.file.read(filename);
                 var $ = cheerio.load(src);
 
@@ -83,6 +84,7 @@ module.exports = function (grunt) {
             }
 
             function extractJs(filename) {
+                grunt.log.debug("Extracting " + filename);
                 var src = grunt.file.read(filename);
                 var syntax = esprima.parse(src, {
                     tolerant: true


### PR DESCRIPTION
This simple change will make it so that running "grunt extract --debug" will list files as they are processed, which makes it much easier to figure out problems with grunt config files, and aborts due to problems in the processed files.
