### PR TITLE
Add support for incremental updates

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -2,6 +2,7 @@ module.exports = (grunt) ->
     @loadNpmTasks('grunt-contrib-clean')
     @loadNpmTasks('grunt-contrib-jshint')
     @loadNpmTasks('grunt-contrib-watch')
+    @loadNpmTasks('grunt-contrib-copy')
     @loadNpmTasks('grunt-mocha-cli')
     @loadNpmTasks('grunt-release')
 
@@ -29,6 +30,11 @@ module.exports = (grunt) ->
                 options:
                     reporter: 'spec'
 
+        copy:
+            test:
+                files:
+                    'tmp/test15.pot': 'test/fixtures/sample.po'
+
         nggettext_extract:
             auto:
                 files:
@@ -44,6 +50,7 @@ module.exports = (grunt) ->
                     'tmp/test12.pot': 'test/fixtures/php.php'
                     'tmp/test13.pot': 'test/fixtures/sort.html'
                     'tmp/test14.pot': 'test/fixtures/concat.js'
+                    'tmp/test15.pot': 'test/fixtures/sample.html'
             manual:
                 files:
                     'tmp/test5.pot': 'test/fixtures/corrupt.html'
@@ -72,4 +79,4 @@ module.exports = (grunt) ->
     @registerTask 'default', ['test']
     @registerTask 'build', ['clean', 'jshint']
     @registerTask 'package', ['build', 'release']
-    @registerTask 'test', ['build', 'nggettext_extract:auto', 'nggettext_extract:custom', 'nggettext_compile', 'mochacli']
+    @registerTask 'test', ['build', 'copy:test', 'nggettext_extract:auto', 'nggettext_extract:custom', 'nggettext_compile', 'mochacli']

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "grunt-mocha-cli": "~1.0.6",
     "grunt-release": "~0.4.0",
     "coffee-script": "~1.6.3",
-    "grunt-contrib-jshint": "~0.7.2"
+    "grunt-contrib-jshint": "~0.7.2",
+    "grunt-contrib-copy": "~0.5.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"
@@ -48,6 +49,7 @@
   "dependencies": {
     "cheerio": "~0.12.2",
     "esprima": "~1.0.3",
-    "pofile": "~0.2.1"
+    "pofile": "~0.2.1",
+    "async": "~0.2.9"
   }
 }

--- a/test/extract.coffee
+++ b/test/extract.coffee
@@ -203,3 +203,21 @@ describe 'Extract', ->
             assert.equal(catalog.items[1].references[0], 'test/fixtures/concat.js')
 
             done()
+
+    it 'Extracts strings and updates existing .pot', (done) ->
+        assert(fs.existsSync('tmp/test15.pot'))
+
+        po.load 'tmp/test15.pot', (err, catalog) ->
+            assert.equal(err, null)
+            assert.equal(catalog.items.length, 2)
+            assert.equal(catalog.items[0].msgid, 'Hello!')
+            assert.equal(catalog.items[0].msgstr, 'Bonjour!')
+            assert.equal(catalog.items[0].references.length, 1)
+            assert.equal(catalog.items[0].references[0], 'test/fixtures/sample.html')
+
+            assert.equal(catalog.items[1].msgid, 'This is a test')
+            assert.equal(catalog.items[1].msgstr, '')
+            assert.equal(catalog.items[1].references.length, 1)
+            assert.equal(catalog.items[1].references[0], 'test/fixtures/sample.html')
+
+            done()

--- a/test/fixtures/sample.html
+++ b/test/fixtures/sample.html
@@ -1,0 +1,7 @@
+<html>
+    <body>
+        <h1 translate>Hello!</h1>
+        <p translate>This is a test</p>
+    </body>
+</html>
+

--- a/test/fixtures/sample.po
+++ b/test/fixtures/sample.po
@@ -1,0 +1,12 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: test/fixtures/sample.html
+msgid "Hello!"
+msgstr "Bonjour!"
+
+#: test/fixtures/sample.html
+msgid "Bird"
+msgstr "Oiseau"


### PR DESCRIPTION
I noticed that running `grunt nggettext_extract` overwrites existing `.pot` files and all existing strings are removed. Since this is a really annoying issue, I took some time to improve the extraction task.

It now loads the `.pot` file referenced by `file.dest`. If it succeeds, it uses the data read from the target file as the catalog. Otherwise, it instanciates a new catalog with some default values (as before). Since `PO.load` is asynchronous, I needed to adapt the existing code to make it work with Grunt.

Note that a new dependency `async` has been added since `grunt.utils.async` is deprecated (http://gruntjs.com/api/grunt.util#grunt.util.async) and cannot be used.

I also added a new test to cover the incremental update of an existing `.pot` file. It checks that all strings that still appear in the template are not overwritten while new strings are added (and deprecated ones removed).
