### PR TITLE
Allow custom gettext alias for extract

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -64,6 +64,11 @@ module.exports = (grunt) ->
                   'tmp/test16.pot': 'test/fixtures/custom.extension'
                   'tmp/test17.pot': 'test/fixtures/custom.js_extension'
                   'tmp/test18.pot': 'test/fixtures/single.html'
+            custom_marker_name:
+                options:
+                    markerName: '__'
+                files:
+                  'tmp/test20.pot': 'test/fixtures/custom_marker_name.js'
 
         nggettext_compile:
             test1:
@@ -89,4 +94,4 @@ module.exports = (grunt) ->
     @registerTask 'default', ['test']
     @registerTask 'build', ['clean', 'jshint']
     @registerTask 'package', ['build', 'release']
-    @registerTask 'test', ['build', 'nggettext_extract:auto', 'nggettext_extract:custom', 'nggettext_extract:custom_extensions', 'nggettext_compile', 'mochacli']
+    @registerTask 'test', ['build', 'nggettext_extract:auto', 'nggettext_extract:custom', 'nggettext_extract:custom_extensions', 'nggettext_extract:custom_marker_name', 'nggettext_compile', 'mochacli']

--- a/tasks/extract.js
+++ b/tasks/extract.js
@@ -20,7 +20,7 @@ module.exports = function (grunt) {
         var options = this.options({
             startDelim: '{{',
             endDelim: '}}',
-            gettextAlias: 'gettext',
+            markerName: 'gettext',
             extensions: {
                 htm: 'html',
                 html: 'html',
@@ -143,7 +143,7 @@ module.exports = function (grunt) {
                     if (node !== null &&
                         node.type === 'CallExpression' &&
                         node.callee !== null &&
-                        node.callee.name === options.gettextAlias &&
+                        node.callee.name === options.markerName &&
                         node["arguments"] !== null &&
                         node["arguments"].length) {
 

--- a/test/extract.coffee
+++ b/test/extract.coffee
@@ -255,3 +255,15 @@ describe 'Extract', ->
             assert.equal(catalog.items[1].references[0], 'test/fixtures/no_delimiter.html')
 
             done()
+
+    it 'Can customize the marker name', (done) ->
+        assert(fs.existsSync('tmp/test20.pot'))
+
+        po.load 'tmp/test20.pot', (err, catalog) ->
+            assert.equal(err, null)
+            assert.equal(catalog.items.length, 1)
+            assert.equal(catalog.items[0].msgid, 'Hello custom')
+            assert.equal(catalog.items[0].msgstr, '')
+            assert.equal(catalog.items[0].references.length, 1)
+            assert.equal(catalog.items[0].references[0], 'test/fixtures/custom_marker_name.js')
+            done()

--- a/test/fixtures/custom_marker_name.js
+++ b/test/fixtures/custom_marker_name.js
@@ -1,0 +1,5 @@
+window.__ = function(str) { return str; };
+
+angular.module("myApp").controller("customController", function (gettext) {
+    var myString = __("Hello custom");
+});


### PR DESCRIPTION
Some developers like using custom gettext "markers" for string translations. A common example is to use the underscore. Generalizing that idea, I added a way to set the gettext alias to whatever the developer wants.

To use the new feature, you can add gettextAlias in the options of the gruntfile, in the same manner as startDelim and endDelim.
