### PR TITLE
Update extract.js to support tapestry 5 templates

### DIFF
--- a/tasks/extract.js
+++ b/tasks/extract.js
@@ -26,6 +26,7 @@ module.exports = function (grunt) {
                 html: 'html',
                 php: 'html',
                 phtml: 'html',
+                tml: 'html',
                 js: 'js'
             }
         });


### PR DESCRIPTION
Im working on a project that uses both the tapestry 5 framework and angular.  Some of the pages will use a combination of technologies and in order to satisfy the tapestry framework I need to provide the markup as tml files. These templates are standard HTML/XHTML; Tapestry extensions to ordinary markup are provided in the form of a Tapestry namespace so in order to use your gettext translation in my application I need a mapping for the tml extension to html.
