### PR TITLE
Add "dest" param for compiler.convertPo in order to check the extension of the destination file

### DIFF
--- a/tasks/compile.js
+++ b/tasks/compile.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
         for (var dest in output) {
             var compiler = new Compiler(options);
 
-            grunt.file.write(dest, compiler.convertPo(output[dest]));
+            grunt.file.write(dest, compiler.convertPo(output[dest], dest));
         }
     });
 };


### PR DESCRIPTION
This change is related to the modifications i made on the angular-gettext-tools project in order to support c# file generation. So you can add in your Gruntfile.js in the nggettext_compile task another destination file having .cs extension 
(ex.  nggettext_compile: {
            all: {
                options: {
                    module: 'app.core',
					namespace:'test',
					defaultLanguage:'fr'
                },
                files: {
                    'Source/WebUI/Scripts/app/core/translation/translations.js': ['po/*.po'],
		   'Source/Core/Common/Translations.cs':['po/*.po']
                }
            },
        },)