### PR TITLE
fix: align versions in package*json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-angular-gettext",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
same story as for https://github.com/rubenv/angular-gettext-tools/pull/197